### PR TITLE
fix for kakoune 2022.10.31

### DIFF
--- a/rc/surround.kak
+++ b/rc/surround.kak
@@ -82,9 +82,9 @@ define-command -override -hidden surround-tag -docstring 'surround tag' %{
 define-command -override -hidden surround-add -params 2 %{
   evaluate-commands -save-regs '"' %{
     set-register '"' %arg{1}
-    execute-keys P
+    execute-keys -draft P
     set-register '"' %arg{2}
-    execute-keys p
+    execute-keys -draft p
   }
 }
 


### PR DESCRIPTION
from kakoune 2022.10.31 changelog:
> p, P, ! and <a-!> commands now select the inserted text

do `execute-keys` in a draft context so that it doesn't lose the selection